### PR TITLE
Make the upstart user declarations work

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,8 +44,8 @@
 define initscript(
   $command,
   $manage_service = true,
-  $user = 'root',
-  $group = 'root',
+  $user = undef,
+  $group = undef,
   $service_ensure = 'running',
   $service_enable = true,
   $has_reload = true,

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -23,8 +23,6 @@ describe 'initscript' do
         .with_content(%r{^DAEMON=foo}) \
         .with_content(%r{^NAME=initscriptname$}) \
         .with_content(%r{^DAEMON_ARGS=\( bar baz\\ \\<baz\\>\\ baz \)$}) \
-        .with_content(%r{^USER=root$}) \
-        .with_content(%r{^GROUP=root$}) \
     }
   end
 

--- a/spec/defines/init_spec.rb
+++ b/spec/defines/init_spec.rb
@@ -98,7 +98,7 @@ describe 'initscript' do
     it {
       should contain_file('initscript initscriptname') \
         .with_path('/etc/init/initscriptname.conf') \
-        .with_content(%r{^script\n\s+foo bar baz\\ \\<baz\\>\\ baz\nend script\n}) \
+        .with_content(%r{^script\n\s+exec foo bar baz\\ \\<baz\\>\\ baz\nend script\n}) \
     }
   end
 
@@ -111,7 +111,7 @@ describe 'initscript' do
     it {
       should contain_file('initscript initscriptname') \
         .with_path('/etc/init/initscriptname.conf')
-        .with_content(%r{^script\n\s+\[ -f /etc/default/initscriptname \] && . /etc/default/initscriptname\n\s+foo bar\nend script\n}) \
+        .with_content(%r{^script\n\s+\[ -f /etc/default/initscriptname \] && . /etc/default/initscriptname\n\s+exec foo bar\nend script\n}) \
     }
   end
 

--- a/templates/launchd.erb
+++ b/templates/launchd.erb
@@ -3,8 +3,12 @@
 <plist version="1.0">
 <dict>
     <key>Label</key>             <string><%= @launchd_name %></string>
+<% unless @user.nil? %>
     <key>UserName</key>          <string><%= @user %></string>
+<% end %>
+<% unless @group.nil? %>
     <key>GroupName</key>         <string><%= @group %></string>
+<% end %>
 <% if @service_enable -%>
     <key>Disabled</key>          <false/>
 <% else -%>

--- a/templates/systemd.erb
+++ b/templates/systemd.erb
@@ -5,8 +5,12 @@ After=basic.target network.target
 
 [Service]
 <% require 'shellwords' %>
+<% unless @user.nil? %>
 User=<%= @user %>
+<% end %>
+<% unless @group.nil? %>
 Group=<%= @group %>
+<% end %>
 ExecStart=<%= @command.shelljoin %>
 <% if @reload_command -%>
 ExecReload=<%= @reload_command.shelljoin %>

--- a/templates/sysv_debian.erb
+++ b/templates/sysv_debian.erb
@@ -61,7 +61,7 @@ do_start()
       --make-pidfile --test > /dev/null \
         || return 1
     start-stop-daemon --start --quiet --pidfile "$PIDFILE" --exec "$DAEMON" \
-      <% unless @user.nil %>--chuid <%= @user.shellescape %><% end %> --background \
+      <% unless @user.nil? %>--chuid <%= @user.shellescape %><% end %> --background \
       --make-pidfile -- "${DAEMON_ARGS[@]}" \
         || return 2
 }

--- a/templates/sysv_debian.erb
+++ b/templates/sysv_debian.erb
@@ -20,8 +20,6 @@ NAME=<%= @name %>
 DAEMON=<%= @command[0].shellescape %>
 PIDFILE="/var/run/$NAME/$NAME.pid"
 DAEMON_ARGS=( <%= @command[1..-1].shelljoin %> )
-USER=<%= @user.shellescape %>
-GROUP=<%= @group.shellescape %>
 SCRIPTNAME="/etc/init.d/$NAME"
 
 # Exit if the package is not installed
@@ -41,8 +39,10 @@ SCRIPTNAME="/etc/init.d/$NAME"
 # Function to create run directory
 #
 mkrundir() {
-        [ ! -d /var/run/<%= @name %> ] && mkdir -p /var/run/<%= @name %>
-        chown "$USER" /var/run/<%= @name %>
+    [ ! -d /var/run/<%= @name %> ] && mkdir -p /var/run/<%= @name %>
+<% unless @user.nil? -%>
+    chown <%= @user.shellescape %> /var/run/<%= @name %>
+<% end -%>
 }
 
 #
@@ -56,10 +56,13 @@ do_start()
     #   2 if daemon could not be started
     echo "Starting $NAME and backgrounding"
     mkrundir
-    start-stop-daemon --start --quiet --pidfile "$PIDFILE" --exec "$DAEMON" --chuid "$USER" --background --make-pidfile --test > /dev/null \
+    start-stop-daemon --start --quiet --pidfile "$PIDFILE" --exec "$DAEMON" \
+      <% unless @user.nil %>--chuid <%= @user.shellescape %><% end %> --background \
+      --make-pidfile --test > /dev/null \
         || return 1
-    start-stop-daemon --start --quiet --pidfile "$PIDFILE" --exec "$DAEMON" --chuid "$USER" --background --make-pidfile -- \
-        "${DAEMON_ARGS[@]}" \
+    start-stop-daemon --start --quiet --pidfile "$PIDFILE" --exec "$DAEMON" \
+      <% unless @user.nil %>--chuid <%= @user.shellescape %><% end %> --background \
+      --make-pidfile -- "${DAEMON_ARGS[@]}" \
         || return 2
 }
 

--- a/templates/sysv_debian.erb
+++ b/templates/sysv_debian.erb
@@ -57,7 +57,7 @@ do_start()
     echo "Starting $NAME and backgrounding"
     mkrundir
     start-stop-daemon --start --quiet --pidfile "$PIDFILE" --exec "$DAEMON" \
-      <% unless @user.nil %>--chuid <%= @user.shellescape %><% end %> --background \
+      <% unless @user.nil? %>--chuid <%= @user.shellescape %><% end %> --background \
       --make-pidfile --test > /dev/null \
         || return 1
     start-stop-daemon --start --quiet --pidfile "$PIDFILE" --exec "$DAEMON" \

--- a/templates/sysv_redhat.erb
+++ b/templates/sysv_redhat.erb
@@ -23,7 +23,9 @@ PID_FILE=/var/run/<%= @name.shellescape %>/pidfile
 #
 mkrundir() {
         [ ! -d /var/run/<%= @name.shellescape %> ] && mkdir -p /var/run/<%= @name.shellescape %>
+<% unless user.nil? -%>
         chown <%= @user.shellescape %> /var/run/<%= @name.shellescape %>
+<% end -%>
 }
 
 #
@@ -36,7 +38,9 @@ mkpidfile() {
         # Create PID file if it didn't exist
         mkrundir
         [ ! -f "$PID_FILE" ] && pidofproc "$COMMAND_NAME" > "$PID_FILE"
+<% unless user.nil? -%>
         chown <%= @user.shellescape %> /var/run/<%= @name.shellescape %>
+<% end -%>
         if [ $? -ne 0 ] ; then
             rm "$PID_FILE"
             KILLPROC_OPT=()
@@ -47,7 +51,7 @@ start() {
         echo -n "Starting "<%= @name.shellescape %>": "
         mkrundir
         [ -f "$PID_FILE" ] && rm "$PID_FILE"
-        daemon --user=<%= @user.shellescape %> \
+        daemon <% unless user.nil? %>--user=<%= @user.shellescape %><% end %> \
             --pidfile="$PID_FILE" \
             <%= @command.shelljoin %> &
         retcode=$?

--- a/templates/sysv_redhat.erb
+++ b/templates/sysv_redhat.erb
@@ -38,7 +38,7 @@ mkpidfile() {
         # Create PID file if it didn't exist
         mkrundir
         [ ! -f "$PID_FILE" ] && pidofproc "$COMMAND_NAME" > "$PID_FILE"
-<% unless user.nil? -%>
+<% unless @user.nil? -%>
         chown <%= @user.shellescape %> /var/run/<%= @name.shellescape %>
 <% end -%>
         if [ $? -ne 0 ] ; then

--- a/templates/sysv_redhat.erb
+++ b/templates/sysv_redhat.erb
@@ -51,7 +51,7 @@ start() {
         echo -n "Starting "<%= @name.shellescape %>": "
         mkrundir
         [ -f "$PID_FILE" ] && rm "$PID_FILE"
-        daemon <% unless user.nil? %>--user=<%= @user.shellescape %><% end %> \
+        daemon <% unless @user.nil? %>--user=<%= @user.shellescape %><% end %> \
             --pidfile="$PID_FILE" \
             <%= @command.shelljoin %> &
         retcode=$?

--- a/templates/sysv_redhat.erb
+++ b/templates/sysv_redhat.erb
@@ -23,7 +23,7 @@ PID_FILE=/var/run/<%= @name.shellescape %>/pidfile
 #
 mkrundir() {
         [ ! -d /var/run/<%= @name.shellescape %> ] && mkdir -p /var/run/<%= @name.shellescape %>
-<% unless user.nil? -%>
+<% unless @user.nil? -%>
         chown <%= @user.shellescape %> /var/run/<%= @name.shellescape %>
 <% end -%>
 }

--- a/templates/upstart.erb
+++ b/templates/upstart.erb
@@ -14,7 +14,9 @@ setgid <%= @group %>
 <% end -%>
 
 script
-    <% if @source_default_file %>[ -f <%= @real_default_file_path.shellescape %> ] && . <%= @real_default_file_path.shellescape %><% end -%>
+<% if @source_default_file %>
+    [ -f <%= @real_default_file_path.shellescape %> ] && . <%= @real_default_file_path.shellescape %>
+<% end -%>
     exec <%= @command.shelljoin %>
 end script
 

--- a/templates/upstart.erb
+++ b/templates/upstart.erb
@@ -6,12 +6,16 @@ start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [06]
 
 <% require 'shellwords' %>
-env USER=<%= @user.shellescape %>
-env GROUP=<%= @group.shellescape %>
+<% unless @user.nil? %>
+setuid <%= @user %>
+<% end -%>
+<% unless @group.nil? %>
+setgid <%= @group %>
+<% end -%>
 
 script
-	<% if @source_default_file %>[ -f <%= @real_default_file_path.shellescape %> ] && . <%= @real_default_file_path.shellescape %><% end %>
-    <%= @command.shelljoin %>
+    <% if @source_default_file %>[ -f <%= @real_default_file_path.shellescape %> ] && . <%= @real_default_file_path.shellescape %><% end -%>
+    exec <%= @command.shelljoin %>
 end script
 
 respawn


### PR DESCRIPTION
Fixes #9

I also made the default for user and group undef. I did this because
Upsart (and many other init systems) will choose these values for you if
left unspecified, and they'll typically know better than this module.
For instance: "If this stanza is unspecified, the primary group of the
user specified in the setuid block is used" (Upstart) and "If no group
is set, the default group of the user is chosen" (systemd).
