### PR TITLE
Rely soley on $PIDFILE in sysv_debian do_stop()

### DIFF
--- a/templates/sysv_debian.erb
+++ b/templates/sysv_debian.erb
@@ -83,9 +83,10 @@ do_stop()
     #   1 if daemon was already stopped
     #   2 if daemon could not be stopped
     #   other if a failure occurred
-    start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile "$PIDFILE" --name "$DAEMON"
+    start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile "$PIDFILE"
     RETVAL="$?"
     [ "$RETVAL" = 2 ] && return 2
+
     # Wait for children to finish too if this is a daemon that forks
     # and if the daemon is only ever run from this initscript.
     # If the above conditions are not satisfied then add some other code
@@ -94,6 +95,7 @@ do_stop()
     # sleep for some time.
     start-stop-daemon --stop --quiet --oknodo --retry=0/30/KILL/5 --exec "$DAEMON"
     [ "$?" = 2 ] && return 2
+
     # Many daemons don't delete their pidfiles when they exit.
     rm -f "$PIDFILE"
     return "$RETVAL"


### PR DESCRIPTION
Using a --name filter when stopping a service is unreliable for two
reasons. First, the name is limited to 15 characters which is very
limiting since we are passing $DAEMON which will be a full path to an
executable. Second, interpreted scripts must match their interpreter and
not the full path to the script.

Instead, rely soley on $PIDFILE which we create in do_start() and should
always exist when the service is running.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/evankrall/puppet-initscript/18)
<!-- Reviewable:end -->
