### PR TITLE
Don't replace upstart files if they are disabled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 spec/fixtures
+vendor/gem

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,7 +58,7 @@
 #   A list of dependencies. Only supported by Upstart and Systemd. Upstart will
 #   assume the dependency is /etc/init/name.conf, Systemd will assume it's
 #   name.service
-define initscript(
+define initscript (
   $command,
   $manage_service = true,
   $user = undef,
@@ -116,9 +116,10 @@ define initscript(
         mode    => '0444',
         owner   => 'root',
         group   => 'root',
+        replace => $service_ensure == 'running',
         content => template('initscript/upstart.erb'),
       }
-      file { "/etc/init.d/${name}":
+      -> file { "/etc/init.d/${name}":
         ensure => link,
         target => '/lib/init/upstart-job',
         owner  => 'root',
@@ -133,8 +134,8 @@ define initscript(
         owner   => 'root',
         group   => 'root',
         content => template('initscript/systemd.erb'),
-      } ~>
-      exec { 'systemctl-daemon-reload':
+      }
+      ~> exec { 'systemctl-daemon-reload':
         command => 'systemctl daemon-reload',
       }
     }
@@ -188,8 +189,8 @@ define initscript(
   if $manage_service {
     #TODO: maybe make the choice of whether to reload the service
     # configurable.
-    File["initscript ${name}"] ~>
-    service { $name:
+    File["initscript ${name}"]
+    ~> service { $name:
       ensure => $service_ensure,
       name   => $init_selector,
       enable => $service_enable,


### PR DESCRIPTION
For upstart, the config file is a template *and* the puppet service provider edits the file. This leads to non-convergence.

The solution is to simple ask puppet to not try to overwrite the file if it is disabled. (not running)

The type of non-convergence this generates looks like this:
```
Notice: /Stage[main]/Signalfx_host_metadata/Initscript[update_signalfx_container_metadata]/File[initscript update_signalfx_container_metadata]/content:
--- /etc/init/update_signalfx_container_metadata.conf	2017-10-26 10:20:32.728924281 -0700
+++ /tmp/puppet-file20171026-93036-1s76ahq	2017-10-26 11:00:03.991233747 -0700
@@ -1,5 +1,5 @@
 #  (Upstart unit)
-#start on (local-filesystems and net-device-up IFACE!=lo)
+start on (local-filesystems and net-device-up IFACE!=lo)
 stop on runlevel [06]

 respawn

Notice: /Stage[main]/Signalfx_host_metadata/Initscript[update_signalfx_container_metadata]/File[initscript update_signalfx_container_metadata]/content: content changed '{md5}cee04cd51e997d2c178fd9576ab15977' to '{md5}e2299d1f276ace73a636d2f3eff45a9b'
```
(because puppet "comments out" the start line when != running)